### PR TITLE
Implement API usage limiter

### DIFF
--- a/app/api/check-usage/route.ts
+++ b/app/api/check-usage/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/app/lib/supabase";
+import { getClientIP, isAllowedIP } from "@/app/lib/utils";
+
+export async function GET(request: NextRequest) {
+  try {
+    const clientIP = getClientIP(request);
+
+    if (isAllowedIP(clientIP)) {
+      return NextResponse.json({
+        remainingRequests: 999, // IPs permitidas tienen acceso ilimitado
+        resetTime: new Date().toISOString(),
+      });
+    }
+
+    const { data: usage, error } = await supabase
+      .from("api_usage")
+      .select("usage_count, last_used")
+      .eq("ip_address", clientIP)
+      .single();
+
+    if (error && error.code !== "PGRST116") {
+      throw error;
+    }
+
+    const MAX_FREE_REQUESTS = 5;
+    const RATE_LIMIT_WINDOW_HOURS = 24;
+
+    if (!usage) {
+      return NextResponse.json({
+        remainingRequests: MAX_FREE_REQUESTS,
+        resetTime: new Date().toISOString(),
+      });
+    }
+
+    // Verificar si han pasado 24 horas
+    const lastUsed = new Date(usage.last_used);
+    const now = new Date();
+    const hoursSinceLastUse =
+      (now.getTime() - lastUsed.getTime()) / (1000 * 60 * 60);
+
+    if (hoursSinceLastUse >= RATE_LIMIT_WINDOW_HOURS) {
+      return NextResponse.json({
+        remainingRequests: MAX_FREE_REQUESTS,
+        resetTime: now.toISOString(),
+      });
+    }
+
+    const remainingRequests = Math.max(
+      0,
+      MAX_FREE_REQUESTS - usage.usage_count
+    );
+    const resetTime = new Date(
+      lastUsed.getTime() + RATE_LIMIT_WINDOW_HOURS * 60 * 60 * 1000
+    );
+
+    return NextResponse.json({
+      remainingRequests,
+      resetTime: resetTime.toISOString(),
+    });
+  } catch (error) {
+    console.error("Error checking usage:", error);
+    return NextResponse.json(
+      { error: "Failed to check usage" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "./contexts/ThemeContext";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import ThemeWrapper from "@/components/ThemeWrapper";
+import { Toaster } from "@/components/ui/sonner";
 
 const manrope = Manrope({
   subsets: ["latin"],
@@ -41,6 +42,7 @@ export default function RootLayout({
             <Footer />
           </ThemeWrapper>
         </ThemeProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,6 +1,38 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+/**
+ * Obtiene la IP real del usuario desde la request
+ * Maneja casos de proxy, load balancer, etc.
+ */
+export function getClientIP(request: Request): string {
+  // Intentar obtener IP de headers comunes de proxy
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    // x-forwarded-for puede contener múltiples IPs, tomar la primera
+    return forwarded.split(",")[0].trim();
+  }
+
+  const realIP = request.headers.get("x-real-ip");
+  if (realIP) {
+    return realIP;
+  }
+
+  // Fallback para desarrollo local
+  return "127.0.0.1";
+}
+
+/**
+ * Verifica si una IP está en la lista de IPs permitidas (para desarrollo)
+ */
+export function isAllowedIP(ip: string): boolean {
+  // Para testing: NO permitir ninguna IP (ni siquiera localhost)
+  return false;
+
+  // O si quieres ser más específico:
+  // return false; // Esto forzará el rate limiting para TODAS las IPs
 }

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -37,6 +37,30 @@ export type Database = {
         };
         Relationships: [];
       };
+      api_usage: {
+        Row: {
+          id: string;
+          ip_address: string;
+          usage_count: number;
+          last_used: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          ip_address: string;
+          usage_count?: number;
+          last_used?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          ip_address?: string;
+          usage_count?: number;
+          last_used?: string;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;
@@ -181,3 +205,36 @@ export const Constants = {
 export type WaitlistRow = Tables<"waitlist">;
 export type WaitlistInsert = TablesInsert<"waitlist">;
 export type WaitlistUpdate = TablesUpdate<"waitlist">;
+
+export type ApiUsageRow = Tables<"api_usage">;
+export type ApiUsageInsert = TablesInsert<"api_usage">;
+export type ApiUsageUpdate = TablesUpdate<"api_usage">;
+
+/**
+ * Obtiene la IP real del usuario desde la request
+ * Maneja casos de proxy, load balancer, etc.
+ */
+export function getClientIP(request: Request): string {
+  // Intentar obtener IP de headers comunes de proxy
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    // x-forwarded-for puede contener múltiples IPs, tomar la primera
+    return forwarded.split(",")[0].trim();
+  }
+
+  const realIP = request.headers.get("x-real-ip");
+  if (realIP) {
+    return realIP;
+  }
+
+  // Fallback para desarrollo local
+  return "127.0.0.1";
+}
+
+/**
+ * Verifica si una IP está en la lista de IPs permitidas (para desarrollo)
+ */
+export function isAllowedIP(ip: string): boolean {
+  const allowedIPs = process.env.ALLOWED_IPS?.split(",") || [];
+  return allowedIPs.includes(ip) || ip === "127.0.0.1" || ip === "::1";
+}

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -14,7 +14,7 @@ export default function WishlistPage() {
     setIsLoading(true);
 
     try {
-      const response = await fetch("/api/waitlist", {
+      const response = await fetch("/api/wishlist", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/components/ui/UsageCounter.tsx
+++ b/components/ui/UsageCounter.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface UsageInfo {
+  remainingRequests: number;
+  resetTime: string;
+}
+
+export function UsageCounter() {
+  const [usageInfo, setUsageInfo] = useState<UsageInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // Obtener información de uso actual
+    const checkUsage = async () => {
+      try {
+        const response = await fetch("/api/check-usage");
+        if (response.ok) {
+          const data = await response.json();
+          setUsageInfo(data);
+        }
+      } catch (error) {
+        console.error("Error checking usage:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkUsage();
+  }, []);
+
+  if (isLoading) return null;
+
+  if (!usageInfo) return null;
+
+  const resetDate = new Date(usageInfo.resetTime);
+  const now = new Date();
+  const timeUntilReset = resetDate.getTime() - now.getTime();
+  const hoursUntilReset = Math.ceil(timeUntilReset / (1000 * 60 * 60));
+
+  return (
+    <div className="text-sm text-muted-foreground">
+      <span className="font-medium">
+        {usageInfo.remainingRequests} free requests remaining
+      </span>
+      {hoursUntilReset > 0 && (
+        <span className="ml-2">• Resets in {hoursUntilReset}h</span>
+      )}
+    </div>
+  );
+}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,25 +1,9 @@
-"use client"
+"use client";
 
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner } from "sonner";
 
-const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+const Toaster = () => {
+  return <Sonner position="top-right" richColors closeButton duration={5000} />;
+};
 
-  return (
-    <Sonner
-      theme={theme as ToasterProps["theme"]}
-      className="toaster group"
-      style={
-        {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-        } as React.CSSProperties
-      }
-      {...props}
-    />
-  )
-}
-
-export { Toaster }
+export { Toaster };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.55.0",
+        "clsx": "^2.1.1",
         "gsap": "^3.13.0",
         "next": "15.4.6",
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "sonner": "^2.0.7"
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2393,6 +2395,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -5807,6 +5817,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",
+    "clsx": "^2.1.1",
     "gsap": "^3.13.0",
     "next": "15.4.6",
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
### Summary
This PR introduces an API usage limiter based on client IP addresses.  
The goal is to restrict anonymous users to a maximum of 5 free requests before redirecting them to the waitlist page.

### Changes
- Created a new `api_usage` table in Supabase to track requests by IP.
- Added a unique index on `ip_address` to prevent duplicates.
- Implemented a PostgreSQL function `update_api_usage(ip TEXT)` to:
  - Insert a new record if the IP is not registered.
  - Increment the `usage_count` and update `last_used` if the IP already exists.
- Set up default timestamps (`created_at`, `last_used`).
- Prepared the logic to enforce free trial limits and block further requests.

### Next Steps
- Integrate backend check: call `update_api_usage` before sending requests to Gemini.
- Redirect users exceeding the free limit to `/wishlist`.

### Motivation
This prevents abuse of the API and ensures that the free trial experience is limited while encouraging users to sign up for extended access.
